### PR TITLE
Add Markdown rendering for chat output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This template demonstrates how to build an AI-powered chat interface using Cloud
 - 🛠️ Built with TypeScript and Cloudflare Workers
 - 📱 Mobile-friendly design
 - 🔄 Maintains chat history on the client
+- 📝 Supports Markdown formatting in assistant responses
 <!-- dash-content-end -->
 
 ## Getting Started

--- a/public/chat.js
+++ b/public/chat.js
@@ -10,6 +10,18 @@ const userInput = document.getElementById("user-input");
 const sendButton = document.getElementById("send-button");
 const typingIndicator = document.getElementById("typing-indicator");
 
+/**
+ * Render Markdown to HTML using marked if available.
+ */
+function renderMarkdown(text) {
+  if (window.marked) {
+    return window.marked.parse(text);
+  }
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+
 // Chat state
 let chatHistory = [
   {
@@ -68,7 +80,7 @@ async function sendMessage() {
     // Create new assistant response element
     const assistantMessageEl = document.createElement("div");
     assistantMessageEl.className = "message assistant-message";
-    assistantMessageEl.innerHTML = "<p></p>";
+    assistantMessageEl.innerHTML = "";
     chatMessages.appendChild(assistantMessageEl);
 
     // Scroll to bottom
@@ -113,7 +125,7 @@ async function sendMessage() {
           if (jsonData.response) {
             // Append new content to existing text
             responseText += jsonData.response;
-            assistantMessageEl.querySelector("p").textContent = responseText;
+            assistantMessageEl.innerHTML = renderMarkdown(responseText);
 
             // Scroll to bottom
             chatMessages.scrollTop = chatMessages.scrollHeight;
@@ -150,7 +162,13 @@ async function sendMessage() {
 function addMessageToChat(role, content) {
   const messageEl = document.createElement("div");
   messageEl.className = `message ${role}-message`;
-  messageEl.innerHTML = `<p>${content}</p>`;
+  if (role === "assistant") {
+    messageEl.innerHTML = renderMarkdown(content);
+  } else {
+    const p = document.createElement("p");
+    p.textContent = content;
+    messageEl.appendChild(p);
+  }
   chatMessages.appendChild(messageEl);
 
   // Scroll to bottom

--- a/public/index.html
+++ b/public/index.html
@@ -128,6 +128,19 @@
         display: block;
       }
 
+      pre {
+        background-color: #272822;
+        color: #f8f8f2;
+        padding: 0.5rem;
+        border-radius: 4px;
+        overflow-x: auto;
+      }
+
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+      }
+
       footer {
         margin-top: 1rem;
         text-align: center;
@@ -171,6 +184,8 @@
       <p>Cloudflare Workers AI Chat Template &copy; 2025</p>
     </footer>
 
+    <!-- Markdown parser -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <!-- Chat app script -->
     <script src="chat.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- format chat messages using Markdown for better display
- include `marked` parser and style code blocks
- document Markdown support

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6889e21def2883299f10a3f9bdb481c7