### PR TITLE
Adjust chat layout widths

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
           Cantarell, sans-serif;
         line-height: 1.6;
         color: var(--text-color);
-        max-width: 800px;
+        width: min(90%, 1024px);
         margin: 0 auto;
         padding: 1rem;
       }
@@ -66,7 +66,8 @@
         margin-bottom: 1rem;
         padding: 0.75rem;
         border-radius: 8px;
-        max-width: 80%;
+        max-width: 95%;
+        overflow-wrap: anywhere;
       }
 
       .user-message {
@@ -134,6 +135,7 @@
         padding: 0.5rem;
         border-radius: 4px;
         overflow-x: auto;
+        width: 100%;
       }
 
       code {


### PR DESCRIPTION
## Summary
- expand main layout to `min(90%, 1024px)`
- widen message bubbles to `95%` and allow long text wrapping
- keep `pre` blocks within message bubbles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e693c81483299513a9831ec067c0