### PR TITLE
Restrict CN access

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -97,7 +97,14 @@ async function sendMessage() {
       }),
     });
 
-    // Handle errors
+    // Blocked region handling
+    if (response.status === 403) {
+      const data = await response.json().catch(() => ({}));
+      addMessageToChat("assistant", data.error || "网站正在建设中");
+      return;
+    }
+
+    // Handle other errors
     if (!response.ok) {
       throw new Error("Failed to get response");
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,18 @@ async function handleChatRequest(
   env: Env,
 ): Promise<Response> {
   try {
+    // Block requests from Mainland China (country code CN)
+    const country = (request as any).cf?.country as string | undefined;
+    if (country && country.toUpperCase() === "CN") {
+      return new Response(
+        JSON.stringify({ error: "网站正在建设中" }),
+        {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+
     // Parse JSON request body
     const { messages = [] } = (await request.json()) as {
       messages: ChatMessage[];


### PR DESCRIPTION
## Summary
- block chat API from CN IPs in `src/index.ts`
- surface a region-block message in the chat frontend

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889f9e8a64083299c773974801ef4bd