### PR TITLE
Add code syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This template demonstrates how to build an AI-powered chat interface using Cloud
 - 📱 Mobile-friendly design
 - 🔄 Maintains chat history on the client
 - 📝 Supports Markdown formatting in assistant responses
+- 🎨 Syntax-highlighted code blocks with highlight.js
 <!-- dash-content-end -->
 
 ## Getting Started

--- a/public/chat.js
+++ b/public/chat.js
@@ -22,6 +22,17 @@ function renderMarkdown(text) {
   return div.innerHTML;
 }
 
+/**
+ * Highlight all code blocks within an element
+ */
+function highlightCode(el) {
+  if (window.hljs) {
+    el.querySelectorAll("pre code").forEach((block) => {
+      window.hljs.highlightElement(block);
+    });
+  }
+}
+
 // Chat state
 let chatHistory = [
   {
@@ -82,6 +93,7 @@ async function sendMessage() {
     assistantMessageEl.className = "message assistant-message";
     assistantMessageEl.innerHTML = "";
     chatMessages.appendChild(assistantMessageEl);
+    highlightCode(assistantMessageEl);
 
     // Scroll to bottom
     chatMessages.scrollTop = chatMessages.scrollHeight;
@@ -133,6 +145,7 @@ async function sendMessage() {
             // Append new content to existing text
             responseText += jsonData.response;
             assistantMessageEl.innerHTML = renderMarkdown(responseText);
+            highlightCode(assistantMessageEl);
 
             // Scroll to bottom
             chatMessages.scrollTop = chatMessages.scrollHeight;
@@ -180,4 +193,5 @@ function addMessageToChat(role, content) {
 
   // Scroll to bottom
   chatMessages.scrollTop = chatMessages.scrollHeight;
+  highlightCode(messageEl);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -194,7 +194,18 @@
 
     <!-- Markdown parser -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <!-- Highlight.js for syntax highlighting -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/highlight.js@11.8.0/styles/github.min.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.8.0/highlight.min.js"></script>
     <!-- Chat app script -->
     <script src="chat.js"></script>
+    <script>
+      if (window.hljs) {
+        window.hljs.highlightAll();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- enable highlight.js in frontend to colorize code blocks
- integrate highlighting in message rendering
- note highlight feature in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a41cbbc38832982f5df582d4592c0