### PR TITLE
Fix highlight.js integration

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -13,8 +13,21 @@ const typingIndicator = document.getElementById("typing-indicator");
 /**
  * Render Markdown to HTML using marked if available.
  */
+let markedConfigured = false;
+
 function renderMarkdown(text) {
   if (window.marked) {
+    if (window.hljs && !markedConfigured) {
+      window.marked.setOptions({
+        highlight(code, lang) {
+          if (lang && window.hljs.getLanguage(lang)) {
+            return window.hljs.highlight(code, { language: lang }).value;
+          }
+          return window.hljs.highlightAuto(code).value;
+        },
+      });
+      markedConfigured = true;
+    }
     return window.marked.parse(text);
   }
   const div = document.createElement("div");


### PR DESCRIPTION
## Summary
- configure `marked` to highlight code with highlight.js

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a46725d608329b8d916bfa32bcb83