### PR TITLE
Add copy button to code blocks

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -38,12 +38,37 @@ function renderMarkdown(text) {
 /**
  * Highlight all code blocks within an element
  */
+function addCopyButtons(el) {
+  el.querySelectorAll("pre").forEach((pre) => {
+    if (pre.querySelector(".copy-btn")) return;
+    const btn = document.createElement("button");
+    btn.className = "copy-btn";
+    btn.textContent = "Copy";
+    btn.addEventListener("click", () => {
+      const code = pre.querySelector("code");
+      const text = code ? code.innerText : pre.innerText;
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          btn.textContent = "Copied!";
+          setTimeout(() => (btn.textContent = "Copy"), 2000);
+        })
+        .catch(() => {
+          btn.textContent = "Failed";
+          setTimeout(() => (btn.textContent = "Copy"), 2000);
+        });
+    });
+    pre.appendChild(btn);
+  });
+}
+
 function highlightCode(el) {
   if (window.hljs) {
     el.querySelectorAll("pre code").forEach((block) => {
       window.hljs.highlightElement(block);
     });
   }
+  addCopyButtons(el);
 }
 
 // Chat state

--- a/public/index.html
+++ b/public/index.html
@@ -136,10 +136,29 @@
       }
 
       pre {
+        position: relative;
         padding: 0.5rem;
         border-radius: 4px;
         overflow-x: auto;
         width: 100%;
+      }
+
+      .copy-btn {
+        position: absolute;
+        top: 0.25rem;
+        right: 0.25rem;
+        font-size: 0.75rem;
+        padding: 2px 6px;
+        border: none;
+        border-radius: 4px;
+        background: rgba(0, 0, 0, 0.4);
+        color: #fff;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+
+      .copy-btn:hover {
+        background: rgba(0, 0, 0, 0.6);
       }
 
       code {


### PR DESCRIPTION
## Summary
- enhance code block display with a copy button overlay
- implement copy button logic in `chat.js`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ae5bc45488329bc54a935ffd80bce