### PR TITLE
feat: support gpt-oss param shapes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,12 @@ export interface ChatMessage {
   role: "system" | "user" | "assistant";
   content: string;
 }
+
+/**
+ * Parameters for the Workers AI `run` method. Some models expect chat
+ * `messages` while others take an `input` array. Both variants also accept a
+ * `max_tokens` limit.
+ */
+export type AiRunParams =
+  | { messages: ChatMessage[]; max_tokens: number }
+  | { input: ChatMessage[]; max_tokens: number };


### PR DESCRIPTION
## Summary
- determine final model id in `handleChatRequest`
- build AI.run params based on model type, using `input` for gpt-oss models
- define `AiRunParams` union type for Workers AI run parameters

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6894618f1f708329b2466f42bc0f5bb4