### PR TITLE
fix openai request parameters for gpt-oss model

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,10 +88,11 @@ async function handleChatRequest(
       messages.unshift({ role: "system", content: systemPrompt });
     }
 
-    // Build parameters based on the model. GPT-OSS models expect `input` while
-    // others accept `messages`.
+    // Build parameters based on the model. GPT-OSS models expect `input` and
+    // use `max_output_tokens`, while others accept `messages` with
+    // `max_tokens`.
     const params: AiRunParams = (modelId as string).includes("gpt-oss")
-      ? { input: messages, max_tokens: 1024 }
+      ? { input: messages, max_output_tokens: 1024 }
       : { messages, max_tokens: 1024 };
 
     const response = await env.AI.run(

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,4 +29,6 @@ export interface ChatMessage {
  */
 export type AiRunParams =
   | { messages: ChatMessage[]; max_tokens: number }
-  | { input: ChatMessage[]; max_tokens: number };
+  | { input: ChatMessage[]; max_tokens: number }
+  | { messages: ChatMessage[]; max_output_tokens: number }
+  | { input: ChatMessage[]; max_output_tokens: number };


### PR DESCRIPTION
## Summary
- use `max_output_tokens` with gpt-oss models and keep `max_tokens` for others
- extend `AiRunParams` to support new parameter

## Testing
- `npm test -- --run --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689467bc9b288329b9fdccce3a4fca75